### PR TITLE
Add ingress for query

### DIFF
--- a/thanos/templates/query-ingress.yaml
+++ b/thanos/templates/query-ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.query.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+{{- if .Values.query.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.query.ingress.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "thanos.name" . }}
+    helm.sh/chart: {{ include "thanos.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ include "thanos.fullname" . }}-query-ingress
+spec:
+  rules:
+  - host: {{ .Values.query.ingress.host }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ include "thanos.fullname" . }}-query-http
+          servicePort: {{ .Values.query.httpService.port }}
+        path: /
+  {{- if .Values.query.ingress.tls }}
+  tls:
+{{ toYaml .Values.query.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/thanos/values.yaml
+++ b/thanos/values.yaml
@@ -102,6 +102,14 @@ query:
     - store.example.local:10901
   queryReplicaLabel: replica
 
+  ingress:
+    enabled: false
+    annotations: {}
+    host: ""
+    tls:
+      - hosts: [ ]
+        secretName: ""
+
   # cert, key and ca are base64 encoded strings
   tlsClient:
     enabled: false


### PR DESCRIPTION
This is needed if we want to connect external Grafana to Query as a Prometheus datasource.